### PR TITLE
Revert "规范语言文字标签"

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="cmn-Hans-CN">
+<html lang="zh-CN">
 <head>
     {{! Document Settings }}
     <meta charset="utf-8" />


### PR DESCRIPTION
现存的浏览器数量众多，还有大量移动端浏览器，目前还没有看到有较全面的测试，个人认为还是使用 zh-CN 更保险
